### PR TITLE
Bug/UB fix and style corrections

### DIFF
--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -132,7 +132,9 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int8_t*>(&value);
+    std::int8_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -143,7 +145,9 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
     const std::uint16_t value = GET_UINT16(buf);
-    return *reinterpret_cast<const int16_t*>(&value);
+    std::int16_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -154,7 +158,9 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const int32_t*>(&value);
+    std::int32_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -166,7 +172,9 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -177,7 +185,9 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -188,7 +198,9 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const float*>(&value);
+    float output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -199,7 +211,9 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const double*>(&value);
+    double output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -52,10 +52,18 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_16(output);
+    }
 #    endif
 #endif
     return (static_cast<std::uint16_t>(buf[0]) << 8) | (static_cast<std::uint16_t>(buf[1]));
@@ -72,10 +80,18 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_32(output);
+    }
 #    endif
 #endif
     return (static_cast<std::uint32_t>(buf[0]) << 24) | (static_cast<std::uint32_t>(buf[1]) << 16) | (static_cast<std::uint32_t>(buf[2]) << 8) | static_cast<std::uint32_t>(buf[3]);
@@ -92,11 +108,19 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     assert(buf);
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
-    if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
+    if(IS_64_ALIGNED(std::uintptr_t(buf))) 
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return output & std::uint64_t(0xFFFFFFFFFFFF);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    }
 #    endif
 #endif
     return (static_cast<std::uint64_t>(buf[0]) << 40) | (static_cast<std::uint64_t>(buf[1]) << 32) | (static_cast<std::uint64_t>(buf[2]) << 24) | (static_cast<std::uint64_t>(buf[3]) << 16)
@@ -114,10 +138,18 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output);
+    }
 #    endif
 #endif
     return (static_cast<std::uint64_t>(buf[0]) << 56) | (static_cast<std::uint64_t>(buf[1]) << 48) | (static_cast<std::uint64_t>(buf[2]) << 40) | (static_cast<std::uint64_t>(buf[3]) << 32)

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -555,7 +555,9 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -565,7 +567,9 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1247,7 +1251,9 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
+    uint8_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT8(buf, arg);
 }
 
 /**
@@ -1257,7 +1263,9 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
+    uint16_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT16(buf, arg);
 }
 
 /**
@@ -1267,7 +1275,9 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1278,7 +1288,9 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT48(buf, arg);
 }
 
 /**
@@ -1288,7 +1300,9 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1298,7 +1312,9 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1308,7 +1324,9 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -1193,7 +1193,7 @@ inline double GET_FLOAT64(const char* buf, const std::size_t offset)
  */
 inline void SET_UINT8(char* buf, const std::uint8_t val)
 {
-    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint8_t*>(&val));
+    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1203,7 +1203,7 @@ inline void SET_UINT8(char* buf, const std::uint8_t val)
  */
 inline void SET_UINT16(char* buf, const std::uint16_t val)
 {
-    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint16_t*>(&val));
+    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1213,7 +1213,7 @@ inline void SET_UINT16(char* buf, const std::uint16_t val)
  */
 inline void SET_UINT32(char* buf, const std::uint32_t val)
 {
-    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint32_t*>(&val));
+    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1224,7 +1224,7 @@ inline void SET_UINT32(char* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(char* buf, const std::uint64_t val)
 {
-    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1234,7 +1234,7 @@ inline void SET_UINT48(char* buf, const std::uint64_t val)
  */
 inline void SET_UINT64(char* buf, const std::uint64_t val)
 {
-    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -988,8 +988,7 @@ inline std::uint64_t GET_UINT64(const char* buf)
  */
 inline int8_t GET_INT8(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int8_t*>(&value);
+    return GET_INT8(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -999,8 +998,7 @@ inline int8_t GET_INT8(const char* buf)
  */
 inline int16_t GET_INT16(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int16_t*>(&value);
+    return GET_INT16(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1010,8 +1008,7 @@ inline int16_t GET_INT16(const char* buf)
  */
 inline int32_t GET_INT32(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int32_t*>(&value);
+    return GET_INT32(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1022,8 +1019,7 @@ inline int32_t GET_INT32(const char* buf)
  */
 inline int64_t GET_INT48(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    return GET_INT48(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1033,8 +1029,7 @@ inline int64_t GET_INT48(const char* buf)
  */
 inline int64_t GET_INT64(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    return GET_INT64(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1044,8 +1039,7 @@ inline int64_t GET_INT64(const char* buf)
  */
 inline float GET_FLOAT32(const char* buf)
 {
-    const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const float*>(&value);
+    return GET_FLOAT32(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1055,8 +1049,7 @@ inline float GET_FLOAT32(const char* buf)
  */
 inline double GET_FLOAT64(const char* buf)
 {
-    const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const double*>(&value);
+    return GET_FLOAT64(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -504,7 +504,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
+    SET_UINT8(buf, val);
 }
 
 /**
@@ -514,7 +514,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
+    SET_UINT16(buf, val);
 }
 
 /**
@@ -524,7 +524,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    SET_UINT32(buf, val);
 }
 
 /**
@@ -535,7 +535,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT48(buf, val);
 }
 
 /**
@@ -545,7 +545,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT64(buf, val);
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -111,14 +111,14 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     if(IS_64_ALIGNED(std::uintptr_t(buf))) 
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return output & std::uint64_t(0xFFFFFFFFFFFF);
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
     }
 #    endif

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -884,7 +884,7 @@ inline void MEMCPY_UINT64(std::uint64_t* dest, const std::uint8_t* src, const st
  */
 inline std::uint8_t GET_UINT8(const char* buf)
 {
-    return GET_UINT8((const std::uint8_t*)buf);
+    return GET_UINT8(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -894,7 +894,7 @@ inline std::uint8_t GET_UINT8(const char* buf)
  */
 inline std::uint16_t GET_UINT16(const char* buf)
 {
-    return GET_UINT16((const std::uint8_t*)buf);
+    return GET_UINT16(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -904,7 +904,7 @@ inline std::uint16_t GET_UINT16(const char* buf)
  */
 inline std::uint32_t GET_UINT32(const char* buf)
 {
-    return GET_UINT32((const std::uint8_t*)buf);
+    return GET_UINT32(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -915,7 +915,7 @@ inline std::uint32_t GET_UINT32(const char* buf)
  */
 inline std::uint64_t GET_UINT48(const char* buf)
 {
-    return GET_UINT48((const std::uint8_t*)buf);
+    return GET_UINT48(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -925,7 +925,7 @@ inline std::uint64_t GET_UINT48(const char* buf)
  */
 inline std::uint64_t GET_UINT64(const char* buf)
 {
-    return GET_UINT64((const std::uint8_t*)buf);
+    return GET_UINT64(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -1147,7 +1147,7 @@ inline double GET_FLOAT64(const char* buf, const std::size_t offset)
  */
 inline void SET_UINT8(char* buf, const std::uint8_t val)
 {
-    SET_UINT8((std::uint8_t*)buf, *reinterpret_cast<const std::uint8_t*>(&val));
+    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -1157,7 +1157,7 @@ inline void SET_UINT8(char* buf, const std::uint8_t val)
  */
 inline void SET_UINT16(char* buf, const std::uint16_t val)
 {
-    SET_UINT16((std::uint8_t*)buf, *reinterpret_cast<const std::uint16_t*>(&val));
+    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -1167,7 +1167,7 @@ inline void SET_UINT16(char* buf, const std::uint16_t val)
  */
 inline void SET_UINT32(char* buf, const std::uint32_t val)
 {
-    SET_UINT32((std::uint8_t*)buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1178,7 +1178,7 @@ inline void SET_UINT32(char* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(char* buf, const std::uint64_t val)
 {
-    SET_UINT48((std::uint8_t*)buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1188,7 +1188,7 @@ inline void SET_UINT48(char* buf, const std::uint64_t val)
  */
 inline void SET_UINT64(char* buf, const std::uint64_t val)
 {
-    SET_UINT64((std::uint8_t*)buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -38,7 +38,7 @@ namespace big {
 inline std::uint8_t GET_UINT8(const std::uint8_t* buf)
 {
     assert(buf);
-    return ((std::uint8_t)buf[0]);
+    return (static_cast<std::uint8_t>(buf[0]));
 }
 
 /**
@@ -52,13 +52,13 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*(const std::uint16_t*)(buf));
+        return std::uint16_t(*reinterpret_cast<const std::uint16_t*>(buf));
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
         return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
 #    endif
 #endif
-    return ((std::uint16_t)buf[0] << 8) | ((std::uint16_t)buf[1]);
+    return (static_cast<std::uint16_t>(buf[0]) << 8) | (static_cast<std::uint16_t>(buf[1]));
 }
 
 /**
@@ -72,13 +72,13 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*(const std::uint32_t*)(buf));
+        return std::uint32_t(*reinterpret_cast<const std::uint32_t*>(buf));
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
         return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
 #    endif
 #endif
-    return ((std::uint32_t)buf[0] << 24) | ((std::uint32_t)buf[1] << 16) | ((std::uint32_t)buf[2] << 8) | ((std::uint32_t)buf[3]);
+    return (static_cast<std::uint32_t>(buf[0]) << 24) | (static_cast<std::uint32_t>(buf[1]) << 16) | (static_cast<std::uint32_t>(buf[2]) << 8) | static_cast<std::uint32_t>(buf[3]);
 }
 
 /**
@@ -93,14 +93,14 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
+        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
         return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
 #    endif
 #endif
-    return ((std::uint64_t)buf[0] << 40) | ((std::uint64_t)buf[1] << 32) | ((std::uint64_t)buf[2] << 24) | ((std::uint64_t)buf[3] << 16)
-           | ((std::uint64_t)buf[4] << 8) | ((std::uint64_t)buf[5]);
+    return (static_cast<std::uint64_t>(buf[0]) << 40) | (static_cast<std::uint64_t>(buf[1]) << 32) | (static_cast<std::uint64_t>(buf[2]) << 24) | (static_cast<std::uint64_t>(buf[3]) << 16)
+           | (static_cast<std::uint64_t>(buf[4]) << 8) | (static_cast<std::uint64_t>(buf[5]));
 }
 
 /**
@@ -114,14 +114,14 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf));
+        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf));
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
         return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
 #    endif
 #endif
-    return ((std::uint64_t)buf[0] << 56) | ((std::uint64_t)buf[1] << 48) | ((std::uint64_t)buf[2] << 40) | ((std::uint64_t)buf[3] << 32)
-           | ((std::uint64_t)buf[4] << 24) | ((std::uint64_t)buf[5] << 16) | ((std::uint64_t)buf[6] << 8) | ((std::uint64_t)buf[7]);
+    return (static_cast<std::uint64_t>(buf[0]) << 56) | (static_cast<std::uint64_t>(buf[1]) << 48) | (static_cast<std::uint64_t>(buf[2]) << 40) | (static_cast<std::uint64_t>(buf[3]) << 32)
+           | (static_cast<std::uint64_t>(buf[4]) << 24) | (static_cast<std::uint64_t>(buf[5]) << 16) | (static_cast<std::uint64_t>(buf[6]) << 8) | (static_cast<std::uint64_t>(buf[7]));
 }
 
 /**
@@ -132,7 +132,7 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    return *reinterpret_cast<const int8_t*>(&value);
 }
 
 /**
@@ -143,7 +143,7 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    return *reinterpret_cast<const int16_t*>(&value);
 }
 
 /**
@@ -154,7 +154,7 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    return *reinterpret_cast<const int32_t*>(&value);
 }
 
 /**
@@ -166,7 +166,7 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -177,7 +177,7 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -188,7 +188,7 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    return *reinterpret_cast<const float*>(&value);
 }
 
 /**
@@ -199,7 +199,7 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    return *reinterpret_cast<const double*>(&value);
 }
 
 /**
@@ -343,7 +343,7 @@ inline double GET_FLOAT64(const std::uint8_t* buf, const std::size_t offset)
  */
 inline void SET_UINT8(std::uint8_t* buf, const std::uint8_t val)
 {
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -357,19 +357,19 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = val;
+        (*reinterpret_cast<std::uint16_t*>(buf)) = val;
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = bswap_16(val);
+        (*reinterpret_cast<std::uint16_t*>(buf)) = bswap_16(val);
         return;
     }
 #    endif
 #endif
-    buf[0] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[1] = (std::uint8_t)(val & 0xFF);
+    buf[0] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -383,21 +383,21 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = val;
+        (*reinterpret_cast<std::uint32_t*>(buf)) = val;
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = bswap_32(val);
+        (*reinterpret_cast<std::uint32_t*>(buf)) = bswap_32(val);
         return;
     }
 #    endif
 #endif
-    buf[0] = (std::uint8_t)((val >> 24) & 0xFF);
-    buf[1] = (std::uint8_t)((val >> 16) & 0xFF);
-    buf[2] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[3] = (std::uint8_t)(val & 0xFF);
+    buf[0] = static_cast<std::uint8_t>((val >> 24) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 16) & 0xFF);
+    buf[2] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[3] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -427,25 +427,25 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = val;
+        (*reinterpret_cast<std::uint64_t*>(buf)) = val;
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = bswap_64(val);
+        (*reinterpret_cast<std::uint64_t*>(buf)) = bswap_64(val);
         return;
     }
 #    endif
 #endif
-    buf[0] = (std::uint8_t)((val >> 56) & 0xFF);
-    buf[1] = (std::uint8_t)((val >> 48) & 0xFF);
-    buf[2] = (std::uint8_t)((val >> 40) & 0xFF);
-    buf[3] = (std::uint8_t)((val >> 32) & 0xFF);
-    buf[4] = (std::uint8_t)((val >> 24) & 0xFF);
-    buf[5] = (std::uint8_t)((val >> 16) & 0xFF);
-    buf[6] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[7] = (std::uint8_t)(val & 0xFF);
+    buf[0] = static_cast<std::uint8_t>((val >> 56) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 48) & 0xFF);
+    buf[2] = static_cast<std::uint8_t>((val >> 40) & 0xFF);
+    buf[3] = static_cast<std::uint8_t>((val >> 32) & 0xFF);
+    buf[4] = static_cast<std::uint8_t>((val >> 24) & 0xFF);
+    buf[5] = static_cast<std::uint8_t>((val >> 16) & 0xFF);
+    buf[6] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[7] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -455,7 +455,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -465,7 +465,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -475,7 +475,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -486,7 +486,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -496,7 +496,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -506,7 +506,7 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -516,7 +516,7 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -936,7 +936,7 @@ inline std::uint64_t GET_UINT64(const char* buf)
 inline int8_t GET_INT8(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    return *reinterpret_cast<const int8_t*>(&value);
 }
 
 /**
@@ -947,7 +947,7 @@ inline int8_t GET_INT8(const char* buf)
 inline int16_t GET_INT16(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    return *reinterpret_cast<const int16_t*>(&value);
 }
 
 /**
@@ -958,7 +958,7 @@ inline int16_t GET_INT16(const char* buf)
 inline int32_t GET_INT32(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    return *reinterpret_cast<const int32_t*>(&value);
 }
 
 /**
@@ -970,7 +970,7 @@ inline int32_t GET_INT32(const char* buf)
 inline int64_t GET_INT48(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -981,7 +981,7 @@ inline int64_t GET_INT48(const char* buf)
 inline int64_t GET_INT64(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -992,7 +992,7 @@ inline int64_t GET_INT64(const char* buf)
 inline float GET_FLOAT32(const char* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    return *reinterpret_cast<const float*>(&value);
 }
 
 /**
@@ -1003,7 +1003,7 @@ inline float GET_FLOAT32(const char* buf)
 inline double GET_FLOAT64(const char* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    return *reinterpret_cast<const double*>(&value);
 }
 
 /**
@@ -1147,7 +1147,7 @@ inline double GET_FLOAT64(const char* buf, const std::size_t offset)
  */
 inline void SET_UINT8(char* buf, const std::uint8_t val)
 {
-    SET_UINT8((std::uint8_t*)buf, *(const std::uint8_t*)&val);
+    SET_UINT8((std::uint8_t*)buf, *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -1157,7 +1157,7 @@ inline void SET_UINT8(char* buf, const std::uint8_t val)
  */
 inline void SET_UINT16(char* buf, const std::uint16_t val)
 {
-    SET_UINT16((std::uint8_t*)buf, *(const std::uint16_t*)&val);
+    SET_UINT16((std::uint8_t*)buf, *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -1167,7 +1167,7 @@ inline void SET_UINT16(char* buf, const std::uint16_t val)
  */
 inline void SET_UINT32(char* buf, const std::uint32_t val)
 {
-    SET_UINT32((std::uint8_t*)buf, *(const std::uint32_t*)&val);
+    SET_UINT32((std::uint8_t*)buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1178,7 +1178,7 @@ inline void SET_UINT32(char* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(char* buf, const std::uint64_t val)
 {
-    SET_UINT48((std::uint8_t*)buf, *(const std::uint64_t*)&val);
+    SET_UINT48((std::uint8_t*)buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1188,7 +1188,7 @@ inline void SET_UINT48(char* buf, const std::uint64_t val)
  */
 inline void SET_UINT64(char* buf, const std::uint64_t val)
 {
-    SET_UINT64((std::uint8_t*)buf, *(const std::uint64_t*)&val);
+    SET_UINT64((std::uint8_t*)buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1198,7 +1198,7 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -1208,7 +1208,7 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -1218,7 +1218,7 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1229,7 +1229,7 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1239,7 +1239,7 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1249,7 +1249,7 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1259,7 +1259,7 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -403,13 +403,14 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint16_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint16_t*>(buf)) = bswap_16(val);
+        uint16_t output = bswap_16(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif
@@ -429,13 +430,14 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint32_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint32_t*>(buf)) = bswap_32(val);
+        uint32_t output = bswap_32(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif
@@ -473,13 +475,14 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint64_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint64_t*>(buf)) = bswap_64(val);
+        uint64_t output = bswap_64(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -142,7 +142,7 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
  */
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint16_t value = GET_UINT16(buf);
     return *reinterpret_cast<const int16_t*>(&value);
 }
 
@@ -153,7 +153,7 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
  */
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint32_t value = GET_UINT32(buf);
     return *reinterpret_cast<const int32_t*>(&value);
 }
 
@@ -165,7 +165,7 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
  */
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint64_t value = GET_UINT64(buf);
     return *reinterpret_cast<const int64_t*>(&value);
 }
 
@@ -176,7 +176,7 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
  */
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint64_t value = GET_UINT64(buf);
     return *reinterpret_cast<const int64_t*>(&value);
 }
 

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -878,7 +878,7 @@ inline void MEMCPY_UINT64(std::uint64_t* dest, const std::uint8_t* src, const st
  */
 inline std::uint8_t GET_UINT8(const char* buf)
 {
-    return GET_UINT8((const std::uint8_t*)buf);
+    return GET_UINT8(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -888,7 +888,7 @@ inline std::uint8_t GET_UINT8(const char* buf)
  */
 inline std::uint16_t GET_UINT16(const char* buf)
 {
-    return GET_UINT16((const std::uint8_t*)buf);
+    return GET_UINT16(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -898,7 +898,7 @@ inline std::uint16_t GET_UINT16(const char* buf)
  */
 inline std::uint32_t GET_UINT32(const char* buf)
 {
-    return GET_UINT32((const std::uint8_t*)buf);
+    return GET_UINT32(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -909,7 +909,7 @@ inline std::uint32_t GET_UINT32(const char* buf)
  */
 inline std::uint64_t GET_UINT48(const char* buf)
 {
-    return GET_UINT48((const std::uint8_t*)buf);
+    return GET_UINT48(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**
@@ -919,7 +919,7 @@ inline std::uint64_t GET_UINT48(const char* buf)
  */
 inline std::uint64_t GET_UINT64(const char* buf)
 {
-    return GET_UINT64((const std::uint8_t*)buf);
+    return GET_UINT64(reinterpret_cast<const std::uint8_t*>(buf));
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -549,7 +549,9 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -559,7 +561,9 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1241,7 +1245,9 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
+    uint8_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT8(buf, arg);
 }
 
 /**
@@ -1251,7 +1257,9 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
+    uint16_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT16(buf, arg);
 }
 
 /**
@@ -1261,7 +1269,9 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1272,7 +1282,9 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT48(buf, arg);
 }
 
 /**
@@ -1282,7 +1294,9 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1292,7 +1306,9 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1302,7 +1318,9 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -49,10 +49,18 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_16(output);
+    }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return (static_cast<std::uint16_t>(buf[1]) << 8) | (static_cast<std::uint16_t>(buf[0]));
@@ -68,10 +76,18 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_32(output);
+    }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return (static_cast<std::uint32_t>(buf[3]) << 24) | (static_cast<std::uint32_t>(buf[2]) << 16) | (static_cast<std::uint32_t>(buf[1]) << 8) | (static_cast<std::uint32_t>(buf[0]));
@@ -88,10 +104,18 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf) & std::uint64_t(0xFFFFFFFFFFFF));
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return output & std::uint64_t(0xFFFFFFFFFFFF);
+    }
 #    endif
 #endif
     return (static_cast<std::uint64_t>(buf[5]) << 40) | (static_cast<std::uint64_t>(buf[4]) << 32) | (static_cast<std::uint64_t>(buf[3]) << 24) | (static_cast<std::uint64_t>(buf[2]) << 16)
@@ -108,10 +132,18 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return (static_cast<std::uint64_t>(buf[7]) << 56) | (static_cast<std::uint64_t>(buf[6]) << 48) | (static_cast<std::uint64_t>(buf[5]) << 40) | (static_cast<std::uint64_t>(buf[4]) << 32)

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -106,14 +106,14 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return output & std::uint64_t(0xFFFFFFFFFFFF);
     }
 #    endif

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -136,7 +136,7 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
  */
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint16_t value = GET_UINT16(buf);
     return *reinterpret_cast<const int16_t*>(&value);
 }
 
@@ -147,7 +147,7 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
  */
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint32_t value = GET_UINT32(buf);
     return *reinterpret_cast<const int32_t*>(&value);
 }
 
@@ -159,7 +159,7 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
  */
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint64_t value = GET_UINT64(buf);
     return *reinterpret_cast<const int64_t*>(&value);
 }
 
@@ -170,7 +170,7 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
  */
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
+    const std::uint64_t value = GET_UINT64(buf);
     return *reinterpret_cast<const int64_t*>(&value);
 }
 

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -1187,7 +1187,7 @@ inline double GET_FLOAT64(const char* buf, const std::size_t offset)
  */
 inline void SET_UINT8(char* buf, const std::uint8_t val)
 {
-    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint8_t*>(&val));
+    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1197,7 +1197,7 @@ inline void SET_UINT8(char* buf, const std::uint8_t val)
  */
 inline void SET_UINT16(char* buf, const std::uint16_t val)
 {
-    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint16_t*>(&val));
+    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1207,7 +1207,7 @@ inline void SET_UINT16(char* buf, const std::uint16_t val)
  */
 inline void SET_UINT32(char* buf, const std::uint32_t val)
 {
-    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint32_t*>(&val));
+    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1218,7 +1218,7 @@ inline void SET_UINT32(char* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(char* buf, const std::uint64_t val)
 {
-    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**
@@ -1228,7 +1228,7 @@ inline void SET_UINT48(char* buf, const std::uint64_t val)
  */
 inline void SET_UINT64(char* buf, const std::uint64_t val)
 {
-    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), val);
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -397,13 +397,14 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint16_t*>(buf)) = bswap_16(val);
+        uint16_t output = bswap_16(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint16_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif
@@ -423,13 +424,14 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint32_t*>(buf)) = bswap_32(val);
+        uint32_t output = bswap_32(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint32_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif
@@ -467,13 +469,14 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint64_t*>(buf)) = bswap_64(val);
+        uint64_t output = bswap_64(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*reinterpret_cast<std::uint64_t*>(buf)) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -498,7 +498,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
+    SET_UINT8(buf, val);
 }
 
 /**
@@ -508,7 +508,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
+    SET_UINT16(buf, val);
 }
 
 /**
@@ -518,7 +518,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
+    SET_UINT32(buf, val);
 }
 
 /**
@@ -529,7 +529,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT48(buf, val);
 }
 
 /**
@@ -539,7 +539,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
+    SET_UINT64(buf, val);
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -55,7 +55,7 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
         return std::uint16_t(*reinterpret_cast<const std::uint16_t*>(buf));
 #    endif
 #endif
-    return ((std::uint16_t)buf[1] << 8) | ((std::uint16_t)buf[0]);
+    return (static_cast<std::uint16_t>(buf[1]) << 8) | (static_cast<std::uint16_t>(buf[0]));
 }
 
 /**
@@ -74,7 +74,7 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
         return std::uint32_t(*reinterpret_cast<const std::uint32_t*>(buf));
 #    endif
 #endif
-    return ((std::uint32_t)buf[3] << 24) | ((std::uint32_t)buf[2] << 16) | ((std::uint32_t)buf[1] << 8) | ((std::uint32_t)buf[0]);
+    return (static_cast<std::uint32_t>(buf[3]) << 24) | (static_cast<std::uint32_t>(buf[2]) << 16) | (static_cast<std::uint32_t>(buf[1]) << 8) | (static_cast<std::uint32_t>(buf[0]));
 }
 
 /**
@@ -94,8 +94,8 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
         return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf) & std::uint64_t(0xFFFFFFFFFFFF));
 #    endif
 #endif
-    return ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32) | ((std::uint64_t)buf[3] << 24) | ((std::uint64_t)buf[2] << 16)
-           | ((std::uint64_t)buf[1] << 8) | ((std::uint64_t)buf[0]);
+    return (static_cast<std::uint64_t>(buf[5]) << 40) | (static_cast<std::uint64_t>(buf[4]) << 32) | (static_cast<std::uint64_t>(buf[3]) << 24) | (static_cast<std::uint64_t>(buf[2]) << 16)
+           | (static_cast<std::uint64_t>(buf[1]) << 8) | (static_cast<std::uint64_t>(buf[0]));
 }
 
 /**
@@ -114,8 +114,8 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
         return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf));
 #    endif
 #endif
-    return ((std::uint64_t)buf[7] << 56) | ((std::uint64_t)buf[6] << 48) | ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32)
-           | ((std::uint64_t)buf[3] << 24) | ((std::uint64_t)buf[2] << 16) | ((std::uint64_t)buf[1] << 8) | ((std::uint64_t)buf[0]);
+    return (static_cast<std::uint64_t>(buf[7]) << 56) | (static_cast<std::uint64_t>(buf[6]) << 48) | (static_cast<std::uint64_t>(buf[5]) << 40) | (static_cast<std::uint64_t>(buf[4]) << 32)
+           | (static_cast<std::uint64_t>(buf[3]) << 24) | (static_cast<std::uint64_t>(buf[2]) << 16) | (static_cast<std::uint64_t>(buf[1]) << 8) | (static_cast<std::uint64_t>(buf[0]));
 }
 
 /**
@@ -449,7 +449,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -459,7 +459,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -469,7 +469,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -480,7 +480,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -490,7 +490,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -500,7 +500,7 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -510,7 +510,7 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -930,7 +930,7 @@ inline std::uint64_t GET_UINT64(const char* buf)
 inline int8_t GET_INT8(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    return *reinterpret_cast<const int8_t*>(&value);
 }
 
 /**
@@ -941,7 +941,7 @@ inline int8_t GET_INT8(const char* buf)
 inline int16_t GET_INT16(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    return *reinterpret_cast<const int16_t*>(&value);
 }
 
 /**
@@ -952,7 +952,7 @@ inline int16_t GET_INT16(const char* buf)
 inline int32_t GET_INT32(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    return *reinterpret_cast<const int32_t*>(&value);
 }
 
 /**
@@ -964,7 +964,7 @@ inline int32_t GET_INT32(const char* buf)
 inline int64_t GET_INT48(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -975,7 +975,7 @@ inline int64_t GET_INT48(const char* buf)
 inline int64_t GET_INT64(const char* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -986,7 +986,7 @@ inline int64_t GET_INT64(const char* buf)
 inline float GET_FLOAT32(const char* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    return *reinterpret_cast<const float*>(&value);
 }
 
 /**
@@ -997,7 +997,7 @@ inline float GET_FLOAT32(const char* buf)
 inline double GET_FLOAT64(const char* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    return *reinterpret_cast<const double*>(&value);
 }
 
 /**
@@ -1141,7 +1141,7 @@ inline double GET_FLOAT64(const char* buf, const std::size_t offset)
  */
 inline void SET_UINT8(char* buf, const std::uint8_t val)
 {
-    SET_UINT8((std::uint8_t*)buf, *(const std::uint8_t*)&val);
+    SET_UINT8(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -1151,7 +1151,7 @@ inline void SET_UINT8(char* buf, const std::uint8_t val)
  */
 inline void SET_UINT16(char* buf, const std::uint16_t val)
 {
-    SET_UINT16((std::uint8_t*)buf, *(const std::uint16_t*)&val);
+    SET_UINT16(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -1161,7 +1161,7 @@ inline void SET_UINT16(char* buf, const std::uint16_t val)
  */
 inline void SET_UINT32(char* buf, const std::uint32_t val)
 {
-    SET_UINT32((std::uint8_t*)buf, *(const std::uint32_t*)&val);
+    SET_UINT32(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1172,7 +1172,7 @@ inline void SET_UINT32(char* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(char* buf, const std::uint64_t val)
 {
-    SET_UINT48((std::uint8_t*)buf, *(const std::uint64_t*)&val);
+    SET_UINT48(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1182,7 +1182,7 @@ inline void SET_UINT48(char* buf, const std::uint64_t val)
  */
 inline void SET_UINT64(char* buf, const std::uint64_t val)
 {
-    SET_UINT64((std::uint8_t*)buf, *(const std::uint64_t*)&val);
+    SET_UINT64(reinterpret_cast<std::uint8_t*>(buf), *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1192,7 +1192,7 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, *reinterpret_cast<const std::uint8_t*>(&val));
 }
 
 /**
@@ -1202,7 +1202,7 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, *reinterpret_cast<const std::uint16_t*>(&val));
 }
 
 /**
@@ -1212,7 +1212,7 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1223,7 +1223,7 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1233,7 +1233,7 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**
@@ -1243,7 +1243,7 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, *reinterpret_cast<const std::uint32_t*>(&val));
 }
 
 /**
@@ -1253,7 +1253,7 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, *reinterpret_cast<const std::uint64_t*>(&val));
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -126,7 +126,9 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int8_t*>(&value);
+    std::int8_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -137,7 +139,9 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
     const std::uint16_t value = GET_UINT16(buf);
-    return *reinterpret_cast<const int16_t*>(&value);
+    std::int16_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -148,7 +152,9 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const int32_t*>(&value);
+    std::int32_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -160,7 +166,9 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -171,7 +179,9 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -182,7 +192,9 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const float*>(&value);
+    float output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -193,7 +205,9 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const double*>(&value);
+    double output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -982,8 +982,7 @@ inline std::uint64_t GET_UINT64(const char* buf)
  */
 inline int8_t GET_INT8(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int8_t*>(&value);
+    return GET_INT8(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -993,8 +992,7 @@ inline int8_t GET_INT8(const char* buf)
  */
 inline int16_t GET_INT16(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int16_t*>(&value);
+    return GET_INT16(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1004,8 +1002,7 @@ inline int16_t GET_INT16(const char* buf)
  */
 inline int32_t GET_INT32(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int32_t*>(&value);
+    return GET_INT32(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1016,8 +1013,7 @@ inline int32_t GET_INT32(const char* buf)
  */
 inline int64_t GET_INT48(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    return GET_INT48(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1027,8 +1023,7 @@ inline int64_t GET_INT48(const char* buf)
  */
 inline int64_t GET_INT64(const char* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *reinterpret_cast<const int64_t*>(&value);
+    return GET_INT64(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1038,8 +1033,7 @@ inline int64_t GET_INT64(const char* buf)
  */
 inline float GET_FLOAT32(const char* buf)
 {
-    const std::uint32_t value = GET_UINT32(buf);
-    return *reinterpret_cast<const float*>(&value);
+    return GET_FLOAT32(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**
@@ -1049,8 +1043,7 @@ inline float GET_FLOAT32(const char* buf)
  */
 inline double GET_FLOAT64(const char* buf)
 {
-    const std::uint64_t value = GET_UINT64(buf);
-    return *reinterpret_cast<const double*>(&value);
+    return GET_FLOAT64(reinterpret_cast<const uint8_t*>(buf));
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -36,7 +36,7 @@ namespace little {
  */
 inline std::uint8_t GET_UINT8(const std::uint8_t* buf)
 {
-    return ((std::uint8_t)buf[0]);
+    return (static_cast<std::uint8_t>(buf[0]));
 }
 
 /**
@@ -52,7 +52,7 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
         return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*(const std::uint16_t*)(buf));
+        return std::uint16_t(*reinterpret_cast<const std::uint16_t*>(buf));
 #    endif
 #endif
     return ((std::uint16_t)buf[1] << 8) | ((std::uint16_t)buf[0]);
@@ -71,7 +71,7 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
         return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*(const std::uint32_t*)(buf));
+        return std::uint32_t(*reinterpret_cast<const std::uint32_t*>(buf));
 #    endif
 #endif
     return ((std::uint32_t)buf[3] << 24) | ((std::uint32_t)buf[2] << 16) | ((std::uint32_t)buf[1] << 8) | ((std::uint32_t)buf[0]);
@@ -91,7 +91,7 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
         return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
+        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf) & std::uint64_t(0xFFFFFFFFFFFF));
 #    endif
 #endif
     return ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32) | ((std::uint64_t)buf[3] << 24) | ((std::uint64_t)buf[2] << 16)
@@ -111,7 +111,7 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
         return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf));
+        return std::uint64_t(*reinterpret_cast<const std::uint64_t*>(buf));
 #    endif
 #endif
     return ((std::uint64_t)buf[7] << 56) | ((std::uint64_t)buf[6] << 48) | ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32)
@@ -126,7 +126,7 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    return *reinterpret_cast<const int8_t*>(&value);
 }
 
 /**
@@ -137,7 +137,7 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    return *reinterpret_cast<const int16_t*>(&value);
 }
 
 /**
@@ -148,7 +148,7 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    return *reinterpret_cast<const int32_t*>(&value);
 }
 
 /**
@@ -160,7 +160,7 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -171,7 +171,7 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    return *reinterpret_cast<const int64_t*>(&value);
 }
 
 /**
@@ -182,7 +182,7 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    return *reinterpret_cast<const float*>(&value);
 }
 
 /**
@@ -193,7 +193,7 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    return *reinterpret_cast<const double*>(&value);
 }
 
 /**
@@ -337,7 +337,7 @@ inline double GET_FLOAT64(const std::uint8_t* buf, const std::size_t offset)
  */
 inline void SET_UINT8(std::uint8_t* buf, const std::uint8_t val)
 {
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -351,19 +351,19 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = bswap_16(val);
+        (*reinterpret_cast<std::uint16_t*>(buf)) = bswap_16(val);
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = val;
+        (*reinterpret_cast<std::uint16_t*>(buf)) = val;
         return;
     }
 #    endif
 #endif
-    buf[1] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -377,21 +377,21 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = bswap_32(val);
+        (*reinterpret_cast<std::uint32_t*>(buf)) = bswap_32(val);
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = val;
+        (*reinterpret_cast<std::uint32_t*>(buf)) = val;
         return;
     }
 #    endif
 #endif
-    buf[3] = (std::uint8_t)((val >> 24) & 0xFF);
-    buf[2] = (std::uint8_t)((val >> 16) & 0xFF);
-    buf[1] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[3] = static_cast<std::uint8_t>((val >> 24) & 0xFF);
+    buf[2] = static_cast<std::uint8_t>((val >> 16) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -402,12 +402,12 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
  */
 inline void SET_UINT48(std::uint8_t* buf, const std::uint64_t val)
 {
-    buf[5] = (std::uint8_t)((val >> 40) & 0xFF);
-    buf[4] = (std::uint8_t)((val >> 32) & 0xFF);
-    buf[3] = (std::uint8_t)((val >> 24) & 0xFF);
-    buf[2] = (std::uint8_t)((val >> 16) & 0xFF);
-    buf[1] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[5] = static_cast<std::uint8_t>((val >> 40) & 0xFF);
+    buf[4] = static_cast<std::uint8_t>((val >> 32) & 0xFF);
+    buf[3] = static_cast<std::uint8_t>((val >> 24) & 0xFF);
+    buf[2] = static_cast<std::uint8_t>((val >> 16) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**
@@ -421,25 +421,25 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = bswap_64(val);
+        (*reinterpret_cast<std::uint64_t*>(buf)) = bswap_64(val);
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = val;
+        (*reinterpret_cast<std::uint64_t*>(buf)) = val;
         return;
     }
 #    endif
 #endif
-    buf[7] = (std::uint8_t)((val >> 56) & 0xFF);
-    buf[6] = (std::uint8_t)((val >> 48) & 0xFF);
-    buf[5] = (std::uint8_t)((val >> 40) & 0xFF);
-    buf[4] = (std::uint8_t)((val >> 32) & 0xFF);
-    buf[3] = (std::uint8_t)((val >> 24) & 0xFF);
-    buf[2] = (std::uint8_t)((val >> 16) & 0xFF);
-    buf[1] = (std::uint8_t)((val >> 8) & 0xFF);
-    buf[0] = (std::uint8_t)(val & 0xFF);
+    buf[7] = static_cast<std::uint8_t>((val >> 56) & 0xFF);
+    buf[6] = static_cast<std::uint8_t>((val >> 48) & 0xFF);
+    buf[5] = static_cast<std::uint8_t>((val >> 40) & 0xFF);
+    buf[4] = static_cast<std::uint8_t>((val >> 32) & 0xFF);
+    buf[3] = static_cast<std::uint8_t>((val >> 24) & 0xFF);
+    buf[2] = static_cast<std::uint8_t>((val >> 16) & 0xFF);
+    buf[1] = static_cast<std::uint8_t>((val >> 8) & 0xFF);
+    buf[0] = static_cast<std::uint8_t>(val & 0xFF);
 }
 
 /**


### PR DESCRIPTION
Changes:
1) [This bug](https://github.com/OlivierLDff/Endn/issues/7) was fixed
2) Cast from pointer of one type to pointer of another type(for example uint64_t* -> int64_t*) is undefined behavior, so I replaced all cases where it was used to memcpy(it can be replaced by bit_cast if old standard support isn't needed)
3) GET_X(const char*) is copy-paste of GET_X(const uint8_t*) so I implement first via second
4) C-style casts were replaced by reinterpret_cast/static_cast