### PR TITLE
🐛 Cast from pointer of one type to pointer of another type(for example uint64_t* -> int64_t*) is undefined behavior, use memcpy instead

### DIFF
--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -504,7 +504,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, val);
 }
 
 /**
@@ -514,7 +514,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, val);
 }
 
 /**
@@ -524,7 +524,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, val);
 }
 
 /**
@@ -535,7 +535,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, val);
 }
 
 /**
@@ -545,7 +545,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, val);
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -403,13 +403,14 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = bswap_16(val);
+        uint16_t output = bswap_16(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif
@@ -429,13 +430,14 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = bswap_32(val);
+        uint32_t output = bswap_32(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif
@@ -473,13 +475,14 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = bswap_64(val);
+        uint64_t output = bswap_64(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    endif

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -52,10 +52,18 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*(const std::uint16_t*)(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_16(output);
+    }
 #    endif
 #endif
     return ((std::uint16_t)buf[0] << 8) | ((std::uint16_t)buf[1]);
@@ -72,10 +80,18 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*(const std::uint32_t*)(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_32(output);
+    }
 #    endif
 #endif
     return ((std::uint32_t)buf[0] << 24) | ((std::uint32_t)buf[1] << 16) | ((std::uint32_t)buf[2] << 8) | ((std::uint32_t)buf[3]);
@@ -92,11 +108,19 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     assert(buf);
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
-    if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
+    if(IS_64_ALIGNED(std::uintptr_t(buf))) 
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return output & std::uint64_t(0xFFFFFFFFFFFF);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    }
 #    endif
 #endif
     return ((std::uint64_t)buf[0] << 40) | ((std::uint64_t)buf[1] << 32) | ((std::uint64_t)buf[2] << 24) | ((std::uint64_t)buf[3] << 16)
@@ -114,10 +138,18 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output);
+    }
 #    endif
 #endif
     return ((std::uint64_t)buf[0] << 56) | ((std::uint64_t)buf[1] << 48) | ((std::uint64_t)buf[2] << 40) | ((std::uint64_t)buf[3] << 32)

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -555,7 +555,9 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -565,7 +567,9 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1247,7 +1251,9 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    uint8_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT8(buf, arg);
 }
 
 /**
@@ -1257,7 +1263,9 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    uint16_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT16(buf, arg);
 }
 
 /**
@@ -1267,7 +1275,9 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1278,7 +1288,9 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT48(buf, arg);
 }
 
 /**
@@ -1288,7 +1300,9 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1298,7 +1312,9 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1308,7 +1324,9 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -111,14 +111,14 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     if(IS_64_ALIGNED(std::uintptr_t(buf))) 
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return output & std::uint64_t(0xFFFFFFFFFFFF);
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
     }
 #    endif

--- a/include/Endn/Big.hpp
+++ b/include/Endn/Big.hpp
@@ -132,7 +132,9 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    std::int8_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -142,8 +144,10 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
  */
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    const std::uint16_t value = GET_UINT16(buf);
+    std::int16_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -153,8 +157,10 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
  */
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    const std::uint32_t value = GET_UINT32(buf);
+    std::int32_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -165,8 +171,10 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
  */
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    const std::uint64_t value = GET_UINT64(buf);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -176,8 +184,10 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
  */
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    const std::uint64_t value = GET_UINT64(buf);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -188,7 +198,9 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    float output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -199,7 +211,9 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    double output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -498,7 +498,7 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
  */
 inline void SET_INT8(std::uint8_t* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    SET_UINT8(buf, val);
 }
 
 /**
@@ -508,7 +508,7 @@ inline void SET_INT8(std::uint8_t* buf, const int8_t val)
  */
 inline void SET_INT16(std::uint8_t* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    SET_UINT16(buf, val);
 }
 
 /**
@@ -518,7 +518,7 @@ inline void SET_INT16(std::uint8_t* buf, const int16_t val)
  */
 inline void SET_INT32(std::uint8_t* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    SET_UINT32(buf, val);
 }
 
 /**
@@ -529,7 +529,7 @@ inline void SET_INT32(std::uint8_t* buf, const int32_t val)
  */
 inline void SET_INT48(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    SET_UINT48(buf, val);
 }
 
 /**
@@ -539,7 +539,7 @@ inline void SET_INT48(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_INT64(std::uint8_t* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    SET_UINT64(buf, val);
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -126,7 +126,9 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 inline int8_t GET_INT8(const std::uint8_t* buf)
 {
     const std::uint8_t value = GET_UINT8(buf);
-    return *(int8_t*)(&value);
+    std::int8_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -136,8 +138,10 @@ inline int8_t GET_INT8(const std::uint8_t* buf)
  */
 inline int16_t GET_INT16(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int16_t*)(&value);
+    const std::uint16_t value = GET_UINT16(buf);
+    std::int16_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -147,8 +151,10 @@ inline int16_t GET_INT16(const std::uint8_t* buf)
  */
 inline int32_t GET_INT32(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int32_t*)(&value);
+    const std::uint32_t value = GET_UINT32(buf);
+    std::int32_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -159,8 +165,10 @@ inline int32_t GET_INT32(const std::uint8_t* buf)
  */
 inline int64_t GET_INT48(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    const std::uint64_t value = GET_UINT64(buf);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -170,8 +178,10 @@ inline int64_t GET_INT48(const std::uint8_t* buf)
  */
 inline int64_t GET_INT64(const std::uint8_t* buf)
 {
-    const std::uint8_t value = GET_UINT8(buf);
-    return *(int64_t*)(&value);
+    const std::uint64_t value = GET_UINT64(buf);
+    std::int64_t output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -182,7 +192,9 @@ inline int64_t GET_INT64(const std::uint8_t* buf)
 inline float GET_FLOAT32(const std::uint8_t* buf)
 {
     const std::uint32_t value = GET_UINT32(buf);
-    return *(float*)(&value);
+    float output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**
@@ -193,7 +205,9 @@ inline float GET_FLOAT32(const std::uint8_t* buf)
 inline double GET_FLOAT64(const std::uint8_t* buf)
 {
     const std::uint64_t value = GET_UINT64(buf);
-    return *(double*)(&value);
+    double output;
+    std::memcpy(&output, &value, sizeof(value));
+    return output;
 }
 
 /**

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -49,10 +49,18 @@ inline std::uint16_t GET_UINT16(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return bswap_16(*reinterpret_cast<const std::uint16_t*>(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_16(output);
+    }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
-        return std::uint16_t(*(const std::uint16_t*)(buf));
+    {
+        uint16_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return ((std::uint16_t)buf[1] << 8) | ((std::uint16_t)buf[0]);
@@ -68,10 +76,18 @@ inline std::uint32_t GET_UINT32(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return bswap_32(*reinterpret_cast<const std::uint32_t*>(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_32(output);
+    }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
-        return std::uint32_t(*(const std::uint32_t*)(buf));
+    {
+        uint32_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return ((std::uint32_t)buf[3] << 24) | ((std::uint32_t)buf[2] << 16) | ((std::uint32_t)buf[1] << 8) | ((std::uint32_t)buf[0]);
@@ -88,10 +104,18 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf) << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf)) & std::uint64_t(0xFFFFFFFFFFFF);
+    {
+        uint64_t output = 0;
+        std::memcpy(&output, buf, sizeof(output));
+        return output & std::uint64_t(0xFFFFFFFFFFFF);
+    }
 #    endif
 #endif
     return ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32) | ((std::uint64_t)buf[3] << 24) | ((std::uint64_t)buf[2] << 16)
@@ -108,10 +132,18 @@ inline std::uint64_t GET_UINT64(const std::uint8_t* buf)
 #ifdef ENDN_ENABLE_BSWAP
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return bswap_64(*reinterpret_cast<const std::uint64_t*>(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return bswap_64(output);
+    }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
-        return std::uint64_t(*(const std::uint64_t*)(buf));
+    {
+        uint64_t output;
+        std::memcpy(&output, buf, sizeof(output));
+        return output;
+    }
 #    endif
 #endif
     return ((std::uint64_t)buf[7] << 56) | ((std::uint64_t)buf[6] << 48) | ((std::uint64_t)buf[5] << 40) | ((std::uint64_t)buf[4] << 32)

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -106,14 +106,14 @@ inline std::uint64_t GET_UINT48(const std::uint8_t* buf)
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return bswap_64(output << 16) & std::uint64_t(0x0000FFFFFFFFFFFF);
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
         uint64_t output = 0;
-        std::memcpy(&output, buf, sizeof(output));
+        std::memcpy(&output, buf, 6);
         return output & std::uint64_t(0xFFFFFFFFFFFF);
     }
 #    endif

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -397,13 +397,14 @@ inline void SET_UINT16(std::uint8_t* buf, const std::uint16_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = bswap_16(val);
+        uint16_t output = bswap_16(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_16_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint16_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif
@@ -423,13 +424,14 @@ inline void SET_UINT32(std::uint8_t* buf, const std::uint32_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = bswap_32(val);
+        uint32_t output = bswap_32(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_32_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint32_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif
@@ -467,13 +469,14 @@ inline void SET_UINT64(std::uint8_t* buf, const std::uint64_t val)
 #    ifdef ENDN_IS_BIG_ENDIAN
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = bswap_64(val);
+        uint64_t output = bswap_64(val);
+        std::memcpy(buf, &output, sizeof(output));
         return;
     }
 #    else
     if(IS_64_ALIGNED(std::uintptr_t(buf)))
     {
-        (*(std::uint64_t*)buf) = val;
+        std::memcpy(buf, &val, sizeof(val));
         return;
     }
 #    endif

--- a/include/Endn/Little.hpp
+++ b/include/Endn/Little.hpp
@@ -549,7 +549,9 @@ inline void SET_INT64(std::uint8_t* buf, const int64_t val)
  */
 inline void SET_FLOAT32(std::uint8_t* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -559,7 +561,9 @@ inline void SET_FLOAT32(std::uint8_t* buf, const float val)
  */
 inline void SET_FLOAT64(std::uint8_t* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1241,7 +1245,9 @@ inline void SET_UINT64(char* buf, const std::uint64_t val)
  */
 inline void SET_INT8(char* buf, const int8_t val)
 {
-    SET_UINT8(buf, *(const std::uint8_t*)&val);
+    uint8_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT8(buf, arg);
 }
 
 /**
@@ -1251,7 +1257,9 @@ inline void SET_INT8(char* buf, const int8_t val)
  */
 inline void SET_INT16(char* buf, const int16_t val)
 {
-    SET_UINT16(buf, *(const std::uint16_t*)&val);
+    uint16_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT16(buf, arg);
 }
 
 /**
@@ -1261,7 +1269,9 @@ inline void SET_INT16(char* buf, const int16_t val)
  */
 inline void SET_INT32(char* buf, const int32_t val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1272,7 +1282,9 @@ inline void SET_INT32(char* buf, const int32_t val)
  */
 inline void SET_INT48(char* buf, const int64_t val)
 {
-    SET_UINT48(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT48(buf, arg);
 }
 
 /**
@@ -1282,7 +1294,9 @@ inline void SET_INT48(char* buf, const int64_t val)
  */
 inline void SET_INT64(char* buf, const int64_t val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**
@@ -1292,7 +1306,9 @@ inline void SET_INT64(char* buf, const int64_t val)
  */
 inline void SET_FLOAT32(char* buf, const float val)
 {
-    SET_UINT32(buf, *(const std::uint32_t*)&val);
+    uint32_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT32(buf, arg);
 }
 
 /**
@@ -1302,7 +1318,9 @@ inline void SET_FLOAT32(char* buf, const float val)
  */
 inline void SET_FLOAT64(char* buf, const double val)
 {
-    SET_UINT64(buf, *(const std::uint64_t*)&val);
+    uint64_t arg;
+    std::memcpy(&arg, &val, sizeof(val));
+    SET_UINT64(buf, arg);
 }
 
 /**


### PR DESCRIPTION
Cast from pointer of one type to pointer of another type(for example uint64_t* -> int64_t*) is undefined behavior, so I replaced all cases where it was used to memcpy(it can be replaced by bit_cast if old standard support isn't needed)